### PR TITLE
Update to use new JobMgr domain

### DIFF
--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -10,7 +10,7 @@ ingress:
     traefik.ingress.kubernetes.io/router.middlewares: "alphasynthesis-molli-prod-domain-redirect@kubernetescrd"
 
 config:
-  hostname: "https://jobmgr.mmli1.ncsa.illinois.edu"
+  hostname: "https://jobmgr.platform.moleculemaker.org"
   basePath: "api/v1"
   signInUrl: "https://auth.platform.moleculemaker.org/oauth2/start?rd=https%3A%2F%2Fmolli.platform.moleculemaker.org%2Fconfiguration"
   signOutUrl: "https://auth.platform.moleculemaker.org/oauth2/sign_out?rd=https%3A%2F%2Fmolli.platform.moleculemaker.org%2Fconfiguration"


### PR DESCRIPTION
## Problem
MOLLI users who are logged-in always get a 401 when submitting a new job

Related to #13 

## Approach
Updated JobMgr to use a new domain that matches the suffix of other prod services: `jobmgr.platform.moleculemaker.org`

See https://github.com/moleculemaker/mmli-job-manager/pull/32

This triggers the browser to include the user's OAuth2 Proxy cookie when sending as `withCredentials=true` 

## How to Test
This is currently deployed as a hotfix in production: https://molli.platform.moleculemaker.org/

Notice that all requests are now being sent to https://jobmgr.platform.moleculemaker.org